### PR TITLE
Remove INil.

### DIFF
--- a/src/main/scala/coproduct.scala
+++ b/src/main/scala/coproduct.scala
@@ -7,6 +7,7 @@ object coproduct {
   final case class Inl[+H, +T](head: H) extends Cocons[H, T]
   final case class Inr[+H, +T](tail: T) extends Cocons[H, T]
 
+  type CNil = HFix[Nothing, Nothing]
   type :+:[H, T <: Inductive] = HFix[Cocons[H, ?], T]
 
   trait Inject[C <: Inductive, I] {

--- a/src/main/scala/hlist.scala
+++ b/src/main/scala/hlist.scala
@@ -2,9 +2,9 @@ package test
 
 import hfix._
 object hlist {
-  type HNil = HFix[ListF[Nil, ?], INil]
-  type ::[X, XS <: Inductive] = HFix[ListF[X, ?], XS]
+  type HNil = HFix[Nil, Uninhabited]
+  type ::[X, XS <: Inductive] = HFix[Cons[X, ?], XS]
 
-  val hnil: HNil = HFix[ListF[Nil, ?], INil](Nil)
-  def hcons[X, XS <: Inductive](x: X, xs: XS): X :: XS = HFix[ListF[X, ?], XS](Cons(x, xs))
+  val hnil: HNil = HFix[Nil, Uninhabited](Nil())
+  def hcons[X, XS <: Inductive](x: X, xs: XS): X :: XS = HFix[Cons[X, ?], XS](Cons(x, xs))
 }

--- a/src/main/scala/inductive.scala
+++ b/src/main/scala/inductive.scala
@@ -18,7 +18,6 @@ package hfix {
 
   trait Inductive
   case class HFix[F[_], R <: Inductive](f: F[R]) extends Inductive
-  trait INil extends Inductive
 
   package ops {
     trait Cata[HF, L <: Inductive] extends DepFn1[L]
@@ -37,10 +36,10 @@ package hfix {
 
       def apply[HF <: Poly, L <: Inductive](implicit c: Cata[HF, L]): Aux[HF, L, c.Out] = c
 
-      implicit def lastCata[HF <: Poly, F[_]](implicit fc: Functor[F], f: Case1[HF, F[INil]]): Aux[HF, HFix[F, INil], f.Result] =
-        new Cata[HF, HFix[F, INil]] {
-          type Out = f.Result
-          def apply(t: HFix[F, INil]) = f(t.f)
+      implicit def nothingCata[HF <: Poly, R]: Aux[HF, Uninhabited, R] =
+        new Cata[HF, Uninhabited] {
+          type Out = R
+          def apply(t: Uninhabited) = t
         }
     }
   }
@@ -50,4 +49,9 @@ package hfix {
     def cata[HF <: Poly, L <: Inductive](l: L, f: HF)(implicit c: Cata[HF, L]) =
       c(l)
   }
+}
+
+package object hfix {
+  // see Miles Sabin's workaround at https://issues.scala-lang.org/browse/SI-9453
+  type Uninhabited = Nothing { type T = Unit }
 }

--- a/src/main/scala/list.scala
+++ b/src/main/scala/list.scala
@@ -1,18 +1,27 @@
 package test
 
 trait ListF[+A, +S]
-trait Nil extends ListF[Nothing, Nothing]
-object Nil extends Nil
+case class Nil[+S]() extends ListF[Nothing, S]
 case class Cons[A, +S](x: A, xs: S) extends ListF[A, S]
 
 import cats.Functor
 
 object ListF {
+  implicit def nilFunctor =
+    new Functor[Nil] {
+      def map[A, B](fa: Nil[A])(f: A => B): Nil[B] = Nil()
+    }
+
+  implicit def consFunctor[T] =
+    new Functor[Cons[T, ?]] {
+      def map[A, B](fa: Cons[T, A])(f: A => B): Cons[T, B] = Cons(fa.x, f(fa.xs))
+    }
+
   implicit def listFFunctor[T] =
     new Functor[ListF[T, ?]] {
       def map[A, B](fa: ListF[T, A])(f: A => B): ListF[T, B] =
         fa match {
-          case Nil => Nil
+          case Nil() => Nil()
           case Cons(x, xs) => Cons(x, f(xs))
         }
     }
@@ -21,6 +30,6 @@ object ListF {
 object list {
   import fix._
   type List[A] = Fix[ListF[A, ?]]
-  def nil[A] = Fix[ListF[A, ?]](Nil)
+  def nil[A] = Fix[ListF[A, ?]](Nil())
   def cons[A] = (x: A, xs: List[A]) => Fix[ListF[A, ?]](Cons(x, xs))
 }

--- a/src/test/scala/tests.scala
+++ b/src/test/scala/tests.scala
@@ -17,7 +17,7 @@ class RulesSpec extends WordSpec with Matchers {
 
       val sumList =
         cata[Int, ListF[Int, ?]] {
-          case Nil => 0
+          case Nil() => 0
           case Cons(x, n) => x + n
         } _
 
@@ -34,10 +34,10 @@ class RulesSpec extends WordSpec with Matchers {
       val xs: Int :: Int :: Int :: HNil = hcons(1, hcons(2, hcons(3, hnil)))
 
       object plus extends Poly1 {
-        implicit def caseNil =
-          at[ListF[Nil, INil]] { _ => 0 }
+        implicit def caseNil[A] =
+          at[Nil[A]] { _ => 0 }
         implicit def caseInt =
-          at[ListF[Int, Int]] {
+          at[Cons[Int, Int]] {
             case Cons(x, n) => x + n
           }
       }
@@ -53,9 +53,9 @@ class RulesSpec extends WordSpec with Matchers {
 
     "implement a coproduct" in {
       import coproduct._
-      Coproduct[Int :+: String :+: INil](1) shouldBe HFix(Inl(1))
-      Coproduct[Int :+: String :+: INil]("bar") shouldBe HFix(Inr(HFix(Inl("bar"))))
-      illTyped("Coproduct[Int :+: String :+: INil](1.2)")
+      Coproduct[Int :+: String :+: CNil](1) shouldBe HFix(Inl(1))
+      Coproduct[Int :+: String :+: CNil]("bar") shouldBe HFix(Inr(HFix(Inl("bar"))))
+      illTyped("Coproduct[Int :+: String :+: CNil](1.2)")
     }
   }
 }


### PR DESCRIPTION
`Fix` doesn't have a special case for termination. Instead, the argument `F[_]` passed to `Fix` typically has at least one "leaf" constructor.

However, `HFix` had `INil` as a type-level terminating case, which somewhat breaks the parallel with `Fix`.

This PR removes `INil` and instead achieves termination (of implicit resolution) via compile-time knowledge of used `F`'s data constructors. In fact, each of `F`'s data constructors is viewed as a type constructor in its own right. Consequently, we need to provide a `Functor` instance for each of F's constructors separately.